### PR TITLE
Fix bad turnary in leak.t

### DIFF
--- a/t/leak.t
+++ b/t/leak.t
@@ -3,7 +3,7 @@ use warnings;
 use Scalar::Util;
 use Test::More
   defined &Scalar::Util::weaken ? (tests => 3)
-    : skip_all => "Can't prevent leaks without Scalar::Util::weaken";
+    : (skip_all => "Can't prevent leaks without Scalar::Util::weaken");
 
 use Devel::Confess;
 


### PR DESCRIPTION
This breaks in newer Test::More versions. The problem is that this turnary gives test::more 3 args: tests, 3, 'Can't prevent...'.
