### PR TITLE
do not warn about undefined die messages

### DIFF
--- a/lib/Devel/Confess.pm
+++ b/lib/Devel/Confess.pm
@@ -258,6 +258,7 @@ sub _die {
     $! ||= 1;
     return;
   }
+  no warnings 'uninitialized';
   die @convert unless ref $convert[0];
 }
 


### PR DESCRIPTION
Paws::Exception classes in particular sometimes have undefined message payloads, resulting in warnings like "Use of uninitialized value $convert[1] in die at .../Devel/Confess.pm line 261."